### PR TITLE
Resolve missing tool call responses

### DIFF
--- a/src/routes/aiAgents.js
+++ b/src/routes/aiAgents.js
@@ -1133,6 +1133,9 @@ class AIAgent {
   }
 
   async generateResponse(messageData, conversationEntry, whatsappClient = null) {
+    // Variable to store executed tool results - moved outside try-catch for proper scope
+    const executedToolResults = [];
+
     try {
       const OpenAI = require('openai');
 
@@ -1153,9 +1156,6 @@ class AIAgent {
       console.log(
         `🤖 Agent ${this.id} generating response with model ${this.model}`
       );
-
-      // Variable to store executed tool results
-      const executedToolResults = [];
 
       // Build context prompt with rich message information
       const personalityPrompts = {


### PR DESCRIPTION
Move `executedToolResults` declaration to fix `ReferenceError` and OpenAI 400 errors.

The `executedToolResults` variable was declared inside the `try` block, making it inaccessible in the `catch` block. This caused a `ReferenceError` when attempting to log or process tool results after an error, which in turn led to the OpenAI API 400 error because tool responses couldn't be properly handled. Moving its declaration outside the `try-catch` block resolves the scope issue.