### PR TITLE
Remove browser from socketConfig in app.js

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -3570,7 +3570,6 @@ async function createWhatsAppSession(
       version,
       logger: logger.child({ session: sessionId }),
       printQRInTerminal: false,
-      browser: ['WhatsApp Business', 'Chrome', '4.0.0'],
       markOnlineOnConnect: false, // Importante para não receber notificações no app
       defaultQueryTimeoutMs: 60000,
       // Configurações para evitar detecção e melhorar estabilidade


### PR DESCRIPTION
Remove `browser` property from `socketConfig` to use Baileys' default browser configuration.

---
<a href="https://cursor.com/background-agent?bcId=bc-bbe7c37d-5391-4257-8fa6-6fe1d1e4df08">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bbe7c37d-5391-4257-8fa6-6fe1d1e4df08">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>